### PR TITLE
Store 조회 API 구현 (상세/내 스토어/상품 목록)

### DIFF
--- a/__tests__/unit/store.service.test.ts
+++ b/__tests__/unit/store.service.test.ts
@@ -3,12 +3,14 @@ import { StoreRepository } from '../../src/domains/store/store.repository.js';
 import { StoreService } from '../../src/domains/store/store.service.js';
 import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
 import { createStoreMock, createStoreInputMock } from '../mocks/store.mock.js';
+import { NotFoundError } from '../../src/common/utils/errors.js';
 
 describe('StoreService 유닛 테스트', () => {
   let storeService: StoreService;
   let storeRepository: DeepMockProxy<StoreRepository>;
 
   const userId = 'user-id-1';
+  const storeId = 'store-id-1';
 
   // 테스트 케이스가 실행되기 전에 매번 실행
   beforeEach(() => {
@@ -68,6 +70,146 @@ describe('StoreService 유닛 테스트', () => {
       expect(storeRepository.findByUserId).toHaveBeenCalledTimes(1);
       expect(storeRepository.findByUserId).toHaveBeenCalledWith(userId);
       expect(storeRepository.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // 스토어 상세 조회 (공개)
+  describe('getStoreDetail', () => {
+    it('스토어 상세 조회 성공', async () => {
+      // --- 준비 (Arrange) ---
+      const store = createStoreMock({ id: storeId });
+      const favoriteCount = 10;
+
+      storeRepository.findById.mockResolvedValue(store);
+      storeRepository.countFavorites.mockResolvedValue(favoriteCount);
+
+      // --- 실행 (Act) ---
+      const result = await storeService.getStoreDetail(storeId);
+
+      // --- 검증 (Assert) ---
+      expect(storeRepository.findById).toHaveBeenCalledWith(storeId);
+      expect(storeRepository.countFavorites).toHaveBeenCalledWith(storeId);
+      expect(result.store).toEqual(store);
+      expect(result.favoriteCount).toBe(favoriteCount);
+    });
+
+    it('스토어가 존재하지 않으면 NotFoundError 발생', async () => {
+      // --- 준비 (Arrange) ---
+      storeRepository.findById.mockResolvedValue(null);
+
+      // --- 실행 및 검증 (Act & Assert) ---
+      await expect(storeService.getStoreDetail(storeId)).rejects.toThrow(NotFoundError);
+      expect(storeRepository.countFavorites).not.toHaveBeenCalled();
+    });
+  });
+
+  // 내 스토어 상세 조회
+  describe('getMyStoreDetail', () => {
+    it('내 스토어 상세 조회 성공', async () => {
+      // --- 준비 (Arrange) ---
+      const store = createStoreMock({ id: storeId, userId });
+
+      storeRepository.findByUserId.mockResolvedValue(store);
+      storeRepository.countProducts.mockResolvedValue(5);
+      storeRepository.countFavorites.mockResolvedValue(10);
+      storeRepository.countMonthFavorites.mockResolvedValue(3);
+      storeRepository.getTotalSoldCount.mockResolvedValue(100);
+
+      // --- 실행 (Act) ---
+      const result = await storeService.getMyStoreDetail(userId);
+
+      // --- 검증 (Assert) ---
+      expect(storeRepository.findByUserId).toHaveBeenCalledWith(userId);
+      expect(result.store).toEqual(store);
+      expect(result.stats).toEqual({
+        productCount: 5,
+        favoriteCount: 10,
+        monthFavoriteCount: 3,
+        totalSoldCount: 100,
+      });
+    });
+
+    it('스토어가 존재하지 않으면 NotFoundError 발생', async () => {
+      // --- 준비 (Arrange) ---
+      storeRepository.findByUserId.mockResolvedValue(null);
+
+      // --- 실행 및 검증 (Act & Assert) ---
+      await expect(storeService.getMyStoreDetail(userId)).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  // 내 스토어 상품 목록 조회
+  describe('getMyStoreProducts', () => {
+    it('내 스토어 상품 목록 조회 성공', async () => {
+      // --- 준비 (Arrange) ---
+      const store = createStoreMock({ id: storeId, userId });
+      const mockProducts = [
+        {
+          id: 'product-1',
+          image: 'image1.jpg',
+          name: '상품1',
+          price: 10000,
+          isSoldOut: false,
+          discountRate: 0,
+          discountStartTime: null,
+          discountEndTime: null,
+          createdAt: new Date(),
+          stocks: [{ quantity: 5 }, { quantity: 3 }],
+        },
+      ];
+
+      storeRepository.findByUserId.mockResolvedValue(store);
+      storeRepository.findProductsWithStock.mockResolvedValue(mockProducts);
+      storeRepository.countProducts.mockResolvedValue(1);
+
+      // --- 실행 (Act) ---
+      const result = await storeService.getMyStoreProducts(userId, { page: 1, pageSize: 10 });
+
+      // --- 검증 (Assert) ---
+      expect(storeRepository.findByUserId).toHaveBeenCalledWith(userId);
+      expect(storeRepository.findProductsWithStock).toHaveBeenCalledWith(storeId, 0, 10);
+      expect(result.totalCount).toBe(1);
+      expect(result.products).toHaveLength(1);
+      expect(result.products[0].stock).toBe(8); // 5 + 3
+      expect(result.products[0].isDiscount).toBe(false);
+    });
+
+    it('스토어가 존재하지 않으면 NotFoundError 발생', async () => {
+      // --- 준비 (Arrange) ---
+      storeRepository.findByUserId.mockResolvedValue(null);
+
+      // --- 실행 및 검증 (Act & Assert) ---
+      await expect(storeService.getMyStoreProducts(userId, {})).rejects.toThrow(NotFoundError);
+    });
+
+    it('할인 중인 상품 isDiscount가 true', async () => {
+      // --- 준비 (Arrange) ---
+      const store = createStoreMock({ id: storeId, userId });
+      const now = new Date();
+      const mockProducts = [
+        {
+          id: 'product-1',
+          image: 'image1.jpg',
+          name: '할인 상품',
+          price: 10000,
+          isSoldOut: false,
+          discountRate: 20,
+          discountStartTime: new Date(now.getTime() - 1000 * 60 * 60), // 1시간 전
+          discountEndTime: new Date(now.getTime() + 1000 * 60 * 60), // 1시간 후
+          createdAt: new Date(),
+          stocks: [{ quantity: 10 }],
+        },
+      ];
+
+      storeRepository.findByUserId.mockResolvedValue(store);
+      storeRepository.findProductsWithStock.mockResolvedValue(mockProducts);
+      storeRepository.countProducts.mockResolvedValue(1);
+
+      // --- 실행 (Act) ---
+      const result = await storeService.getMyStoreProducts(userId, {});
+
+      // --- 검증 (Assert) ---
+      expect(result.products[0].isDiscount).toBe(true);
     });
   });
 });

--- a/src/domains/store/store.controller.ts
+++ b/src/domains/store/store.controller.ts
@@ -1,6 +1,11 @@
 import type { Request, Response } from 'express';
 import type { StoreService } from './store.service.js';
-import { toStoreResponse } from './store.mapper.js';
+import {
+  toStoreResponse,
+  toStoreDetailResponse,
+  toMyStoreDetailResponse,
+  toMyStoreProductListResponse,
+} from './store.mapper.js';
 import { UnauthorizedError } from '@/common/utils/errors.js';
 
 export class StoreController {
@@ -14,5 +19,34 @@ export class StoreController {
     const store = await this.storeService.createStore(userId, req.body);
 
     res.status(201).json(toStoreResponse(store));
+  };
+
+  // 스토어 상세 조회 (공개)
+  getStoreDetail = async (req: Request, res: Response) => {
+    const { storeId } = req.params;
+
+    const { store, favoriteCount } = await this.storeService.getStoreDetail(storeId);
+
+    res.status(200).json(toStoreDetailResponse(store, favoriteCount));
+  };
+
+  // 내 스토어 상세 조회
+  getMyStoreDetail = async (req: Request, res: Response) => {
+    if (!req.user) throw new UnauthorizedError('인증이 필요합니다.');
+    const userId = req.user.id;
+
+    const { store, stats } = await this.storeService.getMyStoreDetail(userId);
+
+    res.status(200).json(toMyStoreDetailResponse(store, stats));
+  };
+
+  // 내 스토어 상품 목록 조회
+  getMyStoreProducts = async (req: Request, res: Response) => {
+    if (!req.user) throw new UnauthorizedError('인증이 필요합니다.');
+    const userId = req.user.id;
+
+    const { products, totalCount } = await this.storeService.getMyStoreProducts(userId, req.query);
+
+    res.status(200).json(toMyStoreProductListResponse(products, totalCount));
   };
 }

--- a/src/domains/store/store.repository.ts
+++ b/src/domains/store/store.repository.ts
@@ -17,4 +17,60 @@ export class StoreRepository {
   async findById(id: string) {
     return this.prisma.store.findUnique({ where: { id } });
   }
+
+  // 스토어 좋아요 수 조회
+  async countFavorites(storeId: string): Promise<number> {
+    return this.prisma.storeLike.count({ where: { storeId } });
+  }
+
+  // 이번 달 좋아요 수 조회
+  async countMonthFavorites(storeId: string): Promise<number> {
+    const now = new Date();
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+
+    return this.prisma.storeLike.count({
+      where: {
+        storeId,
+        createdAt: { gte: startOfMonth },
+      },
+    });
+  }
+
+  // 스토어 상품 개수 조회
+  async countProducts(storeId: string): Promise<number> {
+    return this.prisma.product.count({ where: { storeId } });
+  }
+
+  // 스토어 총 판매량 조회 (salesCount 합계)
+  async getTotalSoldCount(storeId: string): Promise<number> {
+    const result = await this.prisma.product.aggregate({
+      where: { storeId },
+      _sum: { salesCount: true },
+    });
+    return result._sum.salesCount ?? 0;
+  }
+
+  // 스토어 상품 목록 조회 (재고 합계 포함)
+  async findProductsWithStock(storeId: string, skip: number, take: number) {
+    return this.prisma.product.findMany({
+      where: { storeId },
+      select: {
+        id: true,
+        image: true,
+        name: true,
+        price: true,
+        isSoldOut: true,
+        discountRate: true,
+        discountStartTime: true,
+        discountEndTime: true,
+        createdAt: true,
+        stocks: {
+          select: { quantity: true },
+        },
+      },
+      orderBy: { createdAt: 'desc' },
+      skip,
+      take,
+    });
+  }
 }

--- a/src/domains/store/store.router.ts
+++ b/src/domains/store/store.router.ts
@@ -3,7 +3,7 @@ import { asyncHandler } from '@/common/middlewares/asyncHandler.js';
 import { validate } from '@/common/middlewares/validate.middleware.js';
 import { authenticate, onlySeller } from '@/common/middlewares/auth.middleware.js';
 import { storeController } from './store.container.js';
-import { createStoreSchema } from './store.schema.js';
+import { createStoreSchema, storeIdParamSchema, storeProductQuerySchema } from './store.schema.js';
 
 const storeRouter = Router();
 
@@ -14,6 +14,30 @@ storeRouter.post(
   onlySeller,
   validate(createStoreSchema, 'body'),
   asyncHandler(storeController.createStore),
+);
+
+// GET /api/stores/detail/my - 내 스토어 상세 조회 (판매자 전용)
+storeRouter.get(
+  '/detail/my',
+  authenticate,
+  onlySeller,
+  asyncHandler(storeController.getMyStoreDetail),
+);
+
+// GET /api/stores/detail/my/product - 내 스토어 상품 목록 조회 (판매자 전용)
+storeRouter.get(
+  '/detail/my/product',
+  authenticate,
+  onlySeller,
+  validate(storeProductQuerySchema, 'query'),
+  asyncHandler(storeController.getMyStoreProducts),
+);
+
+// GET /api/stores/:storeId - 스토어 상세 조회 (공개)
+storeRouter.get(
+  '/:storeId',
+  validate(storeIdParamSchema, 'params'),
+  asyncHandler(storeController.getStoreDetail),
 );
 
 export { storeRouter };

--- a/src/domains/store/store.service.ts
+++ b/src/domains/store/store.service.ts
@@ -1,6 +1,7 @@
 import type { StoreRepository } from './store.repository.js';
-import type { CreateStoreBody } from './store.schema.js';
-import { ConflictError } from '@/common/utils/errors.js';
+import type { CreateStoreBody, StoreProductQuery } from './store.schema.js';
+import type { ProductWithStock } from './store.mapper.js';
+import { ConflictError, NotFoundError } from '@/common/utils/errors.js';
 
 export class StoreService {
   constructor(private storeRepository: StoreRepository) {}
@@ -20,5 +21,78 @@ export class StoreService {
     });
 
     return store;
+  }
+
+  // 스토어 상세 조회 (공개)
+  async getStoreDetail(storeId: string) {
+    const store = await this.storeRepository.findById(storeId);
+    if (!store) {
+      throw new NotFoundError('스토어를 찾을 수 없습니다.');
+    }
+
+    const favoriteCount = await this.storeRepository.countFavorites(storeId);
+
+    return { store, favoriteCount };
+  }
+
+  // 내 스토어 상세 조회
+  async getMyStoreDetail(userId: string) {
+    const store = await this.storeRepository.findByUserId(userId);
+    if (!store) {
+      throw new NotFoundError('스토어를 찾을 수 없습니다.');
+    }
+
+    const [productCount, favoriteCount, monthFavoriteCount, totalSoldCount] = await Promise.all([
+      this.storeRepository.countProducts(store.id),
+      this.storeRepository.countFavorites(store.id),
+      this.storeRepository.countMonthFavorites(store.id),
+      this.storeRepository.getTotalSoldCount(store.id),
+    ]);
+
+    return {
+      store,
+      stats: { productCount, favoriteCount, monthFavoriteCount, totalSoldCount },
+    };
+  }
+
+  // 내 스토어 상품 목록 조회
+  async getMyStoreProducts(userId: string, query: StoreProductQuery) {
+    const store = await this.storeRepository.findByUserId(userId);
+    if (!store) {
+      throw new NotFoundError('스토어를 찾을 수 없습니다.');
+    }
+
+    const page = query.page ?? 1;
+    const pageSize = query.pageSize ?? 10;
+    const skip = (page - 1) * pageSize;
+
+    const [products, totalCount] = await Promise.all([
+      this.storeRepository.findProductsWithStock(store.id, skip, pageSize),
+      this.storeRepository.countProducts(store.id),
+    ]);
+
+    // 재고 합계 계산 + isDiscount 판정
+    const now = new Date();
+    const productsWithStock: ProductWithStock[] = products.map((product) => {
+      const stock = product.stocks.reduce((sum, s) => sum + s.quantity, 0);
+      const isDiscount =
+        product.discountRate > 0 &&
+        product.discountStartTime !== null &&
+        product.discountEndTime !== null &&
+        product.discountStartTime <= now &&
+        now <= product.discountEndTime;
+
+      return {
+        id: product.id,
+        image: product.image,
+        name: product.name,
+        price: product.price,
+        stock,
+        isDiscount,
+        createdAt: product.createdAt,
+      };
+    });
+
+    return { products: productsWithStock, totalCount };
   }
 }


### PR DESCRIPTION
## 📝 변경 사항

<!-- 무엇을 변경했는지 간단히 설명해주세요 -->
  - GET `/api/stores/:storeId` - 스토어 상세 조회 (공개)
  - GET `/api/stores/detail/my` - 내 스토어 상세 조회 (판매자)
  - GET `/api/stores/detail/my/product` - 내 스토어 상품 목록 조회 (판매자)

Service (+3 메서드)
  - `getStoreDetail()` - 공개 상세 조회
  - `getMyStoreDetail()` - 내 스토어 상세 (통계 포함)
  - `getMyStoreProducts()` - 내 스토어 상품 목록


Repository (+5 메서드)
  - `countFavorites()` - 스토어 좋아요 수
  - `countMonthFavorites()` - 이번 달 좋아요 수
  - `countProducts()` - 상품 개수
  - `getTotalSoldCount()` - 총 판매량
  - `findProductsWithStock()` - 상품 목록 (재고 포함)

## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 연결해주세요 -->
- 라우트 순서 준수: `/detail/my` → `/detail/my/product` → `/:storeId`  (정적 > 동적)
Closes #36

## ✅ 체크리스트

- [x] 코드 작성 완료
- [x] 로컬에서 테스트 완료
- [x] Lint/Format 검사 통과
- [x] 타입 체크 통과
- [ ] 문서 업데이트 (필요시)

## 💬 참고사항

<!-- 리뷰어에게 알려주고 싶은 내용이나 특별히 확인해야 할 부분 -->
비슷한 패턴의 GET API 인 점을 고려해서 PR 단위를  작게 잡기로 했지만 괜찮을거 같아서 한번 진행해보았습니다.
추가로 .. 테스트 코드는 함께 진행하였습니다. 
실제 코드 중심으로 부탁드리며 여유되시면 테스트 코드도 함께 봐주시면 감사합니다.

  - `getStoreDetail()` - 공개 상세 조회
  - `getMyStoreDetail()` - 내 스토어 상세 (통계 포함)
  - `getMyStoreProducts()` - 내 스토어 상품 목록
<!-- db 스키마 변동, 패키지 변동 사항 꼭 남겨주세요 -->
