### PR TITLE
스토어 수정 API 구현 및 Store-User onDelete Cascade 추가

### DIFF
--- a/__tests__/mocks/store.mock.ts
+++ b/__tests__/mocks/store.mock.ts
@@ -1,5 +1,5 @@
 import type { Store } from '@prisma/client';
-import type { CreateStoreBody } from '../../src/domains/store/store.schema.js';
+import type { CreateStoreBody, UpdateStoreBody } from '../../src/domains/store/store.schema.js';
 
 /**
  * Store Mock 데이터 생성 팩토리
@@ -30,5 +30,16 @@ export const createStoreInputMock = (
   address: '서울시 강남구',
   phoneNumber: '010-1234-5678',
   content: '테스트 스토어 설명입니다.',
+  ...overrides,
+});
+
+/**
+ * 스토어 수정 입력 데이터 (API 요청 body)
+ * src/domains/store/store.schema.ts의 UpdateStoreBody 타입 사용
+ */
+export const updateStoreInputMock = (
+  overrides: Partial<UpdateStoreBody> = {},
+): UpdateStoreBody => ({
+  name: '수정된 스토어',
   ...overrides,
 });

--- a/prisma/migrations/20251210050331_add_cascade_delete_to_store/migration.sql
+++ b/prisma/migrations/20251210050331_add_cascade_delete_to_store/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "stores" DROP CONSTRAINT "stores_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "stores" ADD CONSTRAINT "stores_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,7 +116,7 @@ model Store {
 
   // FK
   userId String @unique // 유저 한 명당 가게 하나라고 가정
-  user   User   @relation(fields: [userId], references: [id])
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   // Relations
   products Product[]

--- a/src/domains/store/store.controller.ts
+++ b/src/domains/store/store.controller.ts
@@ -49,4 +49,15 @@ export class StoreController {
 
     res.status(200).json(toMyStoreProductListResponse(products, totalCount));
   };
+
+  // 스토어 수정
+  updateStore = async (req: Request, res: Response) => {
+    if (!req.user) throw new UnauthorizedError('인증이 필요합니다.');
+    const userId = req.user.id;
+    const { storeId } = req.params;
+
+    const store = await this.storeService.updateStore(storeId, userId, req.body);
+
+    res.status(200).json(toStoreResponse(store));
+  };
 }

--- a/src/domains/store/store.repository.ts
+++ b/src/domains/store/store.repository.ts
@@ -18,6 +18,11 @@ export class StoreRepository {
     return this.prisma.store.findUnique({ where: { id } });
   }
 
+  // 스토어 수정
+  async update(id: string, data: Prisma.StoreUpdateInput) {
+    return this.prisma.store.update({ where: { id }, data });
+  }
+
   // 스토어 좋아요 수 조회
   async countFavorites(storeId: string): Promise<number> {
     return this.prisma.storeLike.count({ where: { storeId } });

--- a/src/domains/store/store.router.ts
+++ b/src/domains/store/store.router.ts
@@ -3,7 +3,12 @@ import { asyncHandler } from '@/common/middlewares/asyncHandler.js';
 import { validate } from '@/common/middlewares/validate.middleware.js';
 import { authenticate, onlySeller } from '@/common/middlewares/auth.middleware.js';
 import { storeController } from './store.container.js';
-import { createStoreSchema, storeIdParamSchema, storeProductQuerySchema } from './store.schema.js';
+import {
+  createStoreSchema,
+  updateStoreSchema,
+  storeIdParamSchema,
+  storeProductQuerySchema,
+} from './store.schema.js';
 
 const storeRouter = Router();
 
@@ -38,6 +43,16 @@ storeRouter.get(
   '/:storeId',
   validate(storeIdParamSchema, 'params'),
   asyncHandler(storeController.getStoreDetail),
+);
+
+// PATCH /api/stores/:storeId - 스토어 수정 (판매자 전용, 본인 스토어만)
+storeRouter.patch(
+  '/:storeId',
+  authenticate,
+  onlySeller,
+  validate(storeIdParamSchema, 'params'),
+  validate(updateStoreSchema, 'body'),
+  asyncHandler(storeController.updateStore),
 );
 
 export { storeRouter };


### PR DESCRIPTION
## 📝 변경 사항

  ### 1. 스토어 수정 API 구현
  - **Endpoint**: `PATCH /api/stores/:storeId`
  - **인증**: Bearer Token (SELLER만)
  - **권한**: 본인 스토어만 수정 가능
  - **응답**: 200 (성공), 400 (검증 실패), 401 (인증 필요), 403 (권한 없음), 404 (스토어 없음)

  ### 2. Store-User 관계에 onDelete: Cascade 추가
  - User 삭제 시 연결된 Store도 자동 삭제
  - 개발 환경에서 테스트 데이터 정리 용이

  ### 변경 파일
  | 파일 | 변경 내용 |
  |------|----------|
  | `store.repository.ts` | `update()` 메서드 추가 |
  | `store.service.ts` | `updateStore()` 메서드 추가 (404, 403 검증) |
  | `store.controller.ts` | `updateStore` 핸들러 추가 |
  | `store.router.ts` | `PATCH /:storeId` 라우트 추가 |
  | `store.mock.ts` | `updateStoreInputMock` 추가 |
  | `store.service.test.ts` | `updateStore` 테스트 3개 추가 |
  | `schema.prisma` | Store-User 관계에 `onDelete: Cascade` 추가 |

  ## 🔗 관련 이슈

  Related to #46

  ## ✅ 체크리스트

  - [x] 코드 작성 완료
  - [x] 로컬에서 테스트 완료
  - [x] Lint/Format 검사 통과
  - [x] 타입 체크 통과
  - [ ] 문서 업데이트 (필요시)

  ## 💬 참고사항

  - **DB 스키마 변동 있음**: `prisma/schema.prisma` 수정
  - **Migration 추가됨**: `20251210050331_add_cascade_delete_to_store`
  - 팀원들은 pull 후 `npx prisma migrate dev` 실행 필요