### PR TITLE
관심 스토어 등록/해제 API 구현

### DIFF
--- a/__tests__/mocks/store.mock.ts
+++ b/__tests__/mocks/store.mock.ts
@@ -1,4 +1,4 @@
-import type { Store } from '@prisma/client';
+import type { Store, StoreLike } from '@prisma/client';
 import type { CreateStoreBody, UpdateStoreBody } from '../../src/domains/store/store.schema.js';
 
 /**
@@ -41,5 +41,17 @@ export const updateStoreInputMock = (
   overrides: Partial<UpdateStoreBody> = {},
 ): UpdateStoreBody => ({
   name: '수정된 스토어',
+  ...overrides,
+});
+
+/**
+ * StoreLike Mock 데이터 생성 팩토리
+ * Unit Test에서 관심 스토어 관련 Repository mock 반환값으로 사용
+ */
+export const createStoreLikeMock = (overrides: Partial<StoreLike> = {}): StoreLike => ({
+  id: 'store-like-id-1',
+  userId: 'user-id-1',
+  storeId: 'store-id-1',
+  createdAt: new Date(),
   ...overrides,
 });

--- a/src/domains/store/store.controller.ts
+++ b/src/domains/store/store.controller.ts
@@ -5,6 +5,7 @@ import {
   toStoreDetailResponse,
   toMyStoreDetailResponse,
   toMyStoreProductListResponse,
+  toFavoriteStoreResponse,
 } from './store.mapper.js';
 import { UnauthorizedError } from '@/common/utils/errors.js';
 
@@ -59,5 +60,27 @@ export class StoreController {
     const store = await this.storeService.updateStore(storeId, userId, req.body);
 
     res.status(200).json(toStoreResponse(store));
+  };
+
+  // 관심 스토어 등록
+  registerFavorite = async (req: Request, res: Response) => {
+    if (!req.user) throw new UnauthorizedError('인증이 필요합니다.');
+    const userId = req.user.id;
+    const { storeId } = req.params;
+
+    const store = await this.storeService.registerFavorite(userId, storeId);
+
+    res.status(201).json(toFavoriteStoreResponse('register', store));
+  };
+
+  // 관심 스토어 해제
+  unregisterFavorite = async (req: Request, res: Response) => {
+    if (!req.user) throw new UnauthorizedError('인증이 필요합니다.');
+    const userId = req.user.id;
+    const { storeId } = req.params;
+
+    const store = await this.storeService.unregisterFavorite(userId, storeId);
+
+    res.status(200).json(toFavoriteStoreResponse('delete', store));
   };
 }

--- a/src/domains/store/store.repository.ts
+++ b/src/domains/store/store.repository.ts
@@ -78,4 +78,25 @@ export class StoreRepository {
       take,
     });
   }
+
+  // 관심 스토어 등록 여부 확인
+  async findFavorite(userId: string, storeId: string) {
+    return this.prisma.storeLike.findUnique({
+      where: { userId_storeId: { userId, storeId } },
+    });
+  }
+
+  // 관심 스토어 등록
+  async createFavorite(userId: string, storeId: string) {
+    return this.prisma.storeLike.create({
+      data: { userId, storeId },
+    });
+  }
+
+  // 관심 스토어 해제
+  async deleteFavorite(userId: string, storeId: string) {
+    return this.prisma.storeLike.delete({
+      where: { userId_storeId: { userId, storeId } },
+    });
+  }
 }

--- a/src/domains/store/store.router.ts
+++ b/src/domains/store/store.router.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { asyncHandler } from '@/common/middlewares/asyncHandler.js';
 import { validate } from '@/common/middlewares/validate.middleware.js';
-import { authenticate, onlySeller } from '@/common/middlewares/auth.middleware.js';
+import { authenticate, onlySeller, onlyBuyer } from '@/common/middlewares/auth.middleware.js';
 import { storeController } from './store.container.js';
 import {
   createStoreSchema,
@@ -53,6 +53,24 @@ storeRouter.patch(
   validate(storeIdParamSchema, 'params'),
   validate(updateStoreSchema, 'body'),
   asyncHandler(storeController.updateStore),
+);
+
+// POST /api/stores/:storeId/favorite - 관심 스토어 등록 (구매자 전용)
+storeRouter.post(
+  '/:storeId/favorite',
+  authenticate,
+  onlyBuyer,
+  validate(storeIdParamSchema, 'params'),
+  asyncHandler(storeController.registerFavorite),
+);
+
+// DELETE /api/stores/:storeId/favorite - 관심 스토어 해제 (구매자 전용)
+storeRouter.delete(
+  '/:storeId/favorite',
+  authenticate,
+  onlyBuyer,
+  validate(storeIdParamSchema, 'params'),
+  asyncHandler(storeController.unregisterFavorite),
 );
 
 export { storeRouter };

--- a/src/domains/store/store.service.ts
+++ b/src/domains/store/store.service.ts
@@ -114,4 +114,44 @@ export class StoreService {
 
     return updatedStore;
   }
+
+  // 관심 스토어 등록
+  async registerFavorite(userId: string, storeId: string) {
+    // 스토어 존재 확인
+    const store = await this.storeRepository.findById(storeId);
+    if (!store) {
+      throw new NotFoundError('스토어를 찾을 수 없습니다.');
+    }
+
+    // 이미 등록 여부 확인
+    const existingFavorite = await this.storeRepository.findFavorite(userId, storeId);
+    if (existingFavorite) {
+      throw new ConflictError('이미 관심 스토어로 등록되어 있습니다.');
+    }
+
+    // 관심 등록
+    await this.storeRepository.createFavorite(userId, storeId);
+
+    return store;
+  }
+
+  // 관심 스토어 해제
+  async unregisterFavorite(userId: string, storeId: string) {
+    // 스토어 존재 확인
+    const store = await this.storeRepository.findById(storeId);
+    if (!store) {
+      throw new NotFoundError('스토어를 찾을 수 없습니다.');
+    }
+
+    // 등록 여부 확인
+    const existingFavorite = await this.storeRepository.findFavorite(userId, storeId);
+    if (!existingFavorite) {
+      throw new NotFoundError('관심 스토어로 등록되어 있지 않습니다.');
+    }
+
+    // 관심 해제
+    await this.storeRepository.deleteFavorite(userId, storeId);
+
+    return store;
+  }
 }


### PR DESCRIPTION
## 📝 변경 사항

  - 관심 스토어 등록 API 구현 (POST /api/stores/:storeId/favorite)
  - 관심 스토어 해제 API 구현 (DELETE /api/stores/:storeId/favorite)
  - BUYER 전용 API (onlyBuyer 미들웨어 적용)


  ## ✅ 체크리스트

  - [x] 코드 작성 완료
  - [x] 로컬에서 테스트 완료
  - [x] Lint/Format 검사 통과
  - [x] 타입 체크 통과
  - [ ] 문서 업데이트 (필요시)

  ## 💬 참고사항

  ## 🔗 관련 이슈
Closed #46 