### PR TITLE
장바구니 api swagger 문서와 실제 응답 불일치 1차 수정

### DIFF
--- a/__tests__/mocks/cart.mock.ts
+++ b/__tests__/mocks/cart.mock.ts
@@ -26,7 +26,6 @@ const date2 = new Date('2025-12-04T05:05:00.861Z');
 export const baseCartMock = {
   id: 'cart-id-1',
   buyerId: 'buyer-id-1',
-  quantity: 1,
   createdAt: date1,
   updatedAt: date2,
 };
@@ -83,6 +82,8 @@ export const createProductMock = (overrides: Partial<ProductRawData> = {}): Prod
     discountRate: 0,
     discountStartTime: null,
     discountEndTime: null,
+    reviewsRating: 1,
+    categoryId: 'category-id-1',
     createdAt: date1,
     updatedAt: date2,
     store: createStoreMock(store),

--- a/src/domains/cart/cart.mapper.ts
+++ b/src/domains/cart/cart.mapper.ts
@@ -28,7 +28,6 @@ import { toStoreResponse as getStoreResponse } from '@/domains/store/store.mappe
 const toCartBaseResponse = (cart: CartBase<Date>): CartBase<string> => ({
   id: cart.id,
   buyerId: cart.buyerId,
-  quantity: cart.quantity,
   createdAt: cart.createdAt.toISOString(),
   updatedAt: cart.updatedAt.toISOString(),
 });
@@ -53,6 +52,7 @@ const toStockResponse = (stock: StockRawData): StockResponse => ({
   quantity: stock.quantity,
   size: {
     id: stock.size.id,
+    name: stock.size.en,
     size: {
       en: stock.size.en,
       ko: stock.size.ko,
@@ -77,6 +77,8 @@ const toProductResponse = (productRawData: ProductRawData): ProductResponse => (
   discountEndTime: productRawData.discountEndTime?.toISOString() ?? null,
   createdAt: productRawData.createdAt.toISOString(),
   updatedAt: productRawData.updatedAt.toISOString(),
+  reviewsRating: productRawData.reviewsRating,
+  categoryId: productRawData.categoryId,
   store: toStoreResponse(productRawData.store),
   stocks: productRawData.stocks.map(toStockResponse),
 });
@@ -93,21 +95,128 @@ export const toGetCartResponse = (rawCart: GetCartRawData): GetCartResponse => (
   ...toCartBaseResponse(rawCart),
   items: rawCart.items.map(toItemResponse),
 });
+// 실제 반환
+// {
+//   "id": "cmimnz6au0001jv043njbfsd1",
+//   "buyerId": "cmimny4n20000jp048jbtbf1f",
+//   "quantity": 0 -------------------------------------- swagger에만 있음
+//   "createdAt": "2025-12-01T04:43:40.327Z",
+//   "updatedAt": "2025-12-01T04:43:40.327Z",
+//   "items": [
+//       {
+//           "id": "cmj250deb0001jo04ybuuoz5y",
+//           "cartId": "cmimnz6au0001jv043njbfsd1",
+//           "productId": "cmc1i97y10055iup6srpu0ht9",
+//           "sizeId": 1,
+//           "quantity": 1,
+//           "createdAt": "2025-12-12T00:37:02.291Z",
+//           "updatedAt": "2025-12-12T00:37:02.291Z",
+//           "product": {
+//               "id": "cmc1i97y10055iup6srpu0ht9",
+//               "storeId": "cmc1i97wi002jiup6s0eo86zo",
+//               "name": "러블리 블라우스",
+//               "price": 31400,
+//               "image": "https://sprint-be-project.s3.ap-northeast-2.amazonaws.com/codiit/1749632940896-러블리 블라우스.jpg",
+//               "discountRate": 5,
+//               "discountStartTime": "2025-06-18T05:22:06.878Z",
+//               "discountEndTime": "2025-06-23T05:22:06.878Z",
+//               "createdAt": "2025-05-24T05:22:07.596Z",
+//               "updatedAt": "2025-06-18T05:22:10.840Z",
+//               "reviewsRating": 4, --------------------------------- swagger에 없음
+//               "categoryId": "cmc1i97sc0000iup6w2i0rkz2", ---------- swagger에 없음
+//               "content": "여성스럽고 우아한 러블리 블라우스입니다. ..." - swagger에 없음, 상품 상세 정보(장바구니에서 쓰이는 곳 없음 필요x)
+//               "isSoldOut": true, ---------------------------------- swagger에 없음, 프론트에서 붙이는 필드 (백엔드에서 넘길 필요x)
+//               "store": {
+//                   "id": "cmc1i97wi002jiup6s0eo86zo",
+//                   "userId": "cmc1i97v5000viup6x3k862vz",
+//                   "name": "유니클로",
+//                   "address": "서울특별시 중구 명동길 45",
+//                   "phoneNumber": "02-2323-2424",
+//                   "content": "베이직 라이프웨어 브랜드",
+//                   "image": "uniqlo.jpg",
+//                   "createdAt": "2025-06-18T05:22:07.554Z",
+//                   "updatedAt": "2025-06-18T05:22:07.554Z",
+//                   "detailAddress": null --------------------------- swagger에 없음, 장바구니에서 사용안함 (필요 x)
+//               },
+//               "stocks": [
+//                   {
+//                       "id": "cmc1i980f00gliup6wqozd8zy",
+//                       "productId": "cmc1i97y10055iup6srpu0ht9",
+//                       "sizeId": 1,
+//                       "quantity": 26,
+//                       "size": {
+//                           "id": 1,
+//                           "name": "XS", -------------------------- swagger에 없음
+//                           "size": {
+//                               "en": "XS",
+//                               "ko": "XS"
+//                           }
+//                       }
+//                   },
+//                   {
+//                       "id": "cmc1i980f00gniup6poof05ti",
+//                       "productId": "cmc1i97y10055iup6srpu0ht9",
+//                       "sizeId": 2,
+//                       "quantity": 3,
+//                       "size": {
+//                           "id": 2,
+//                           "name": "S",
+//                           "size": {
+//                               "en": "Small",
+//                               "ko": "S"
+//                           }
+//                       }
+//                   },
+//                   {
+//                       "id": "cmc1i980f00gpiup6hlicedk3",
+//                       "productId": "cmc1i97y10055iup6srpu0ht9",
+//                       "sizeId": 3,
+//                       "quantity": 5,
+//                       "size": {
+//                           "id": 3,
+//                           "name": "M",
+//                           "size": {
+//                               "en": "Medium",
+//                               "ko": "M"
+//                           }
+//                       }
+//                   }
+//               ]
+//           }
+//       }
 // ============================================
 // 장바구니 생성 응답 객체 변환
 // ============================================
 export const toCreateCartResponse = (rawCart: CreateCartRawData): CreateCartResponse => {
   return toCartBaseResponse(rawCart);
 };
+// 실제 반환 - swagger랑 불일치
+// 단, 프론트에서 create 한 장바구니 데이터를 활용하지 않고 타입또한 지정해놓지 않아서 문제 x
+// 조회 객체에서도 없어서 삭제함
+// {
+//   "id": "cmimnz6au0001jv043njbfsd1",
+//   "buyerId": "cmimny4n20000jp048jbtbf1f",
+//   "quantity": 1 -> swagger 문서에만 있는 부분
+//   "createdAt": "2025-12-01T04:43:40.327Z",
+//   "updatedAt": "2025-12-01T04:43:40.327Z"
+// }
 // ============================================
 // 장바구니 수정 응답 객체 변환
 // ============================================
 export const toUpdateCartResponse = (rawItems: UpdateCartRawData[]): UpdateCartResponse[] => {
   return rawItems.map(toCartItemBaseResponse);
 };
+// 실제 반환 객체 예시 - swagger랑 일치함
+// {
+//   "productId":"cmca1imcl002dntmkxb2240dp",
+//   "sizes": [
+//     {"sizeId":2,"quantity":2}
+//   ]
+// }
 // ============================================
 // 아이템 상세 조회 응답 객체 변환
 // ============================================
+// 프론트에서 호출하는 부분 없음
 export const toGetCartItemResponse = (
   rawItem: GetCartItemDetailRawData,
 ): GetCartItemDetailResponse => ({

--- a/src/domains/cart/cart.repository.ts
+++ b/src/domains/cart/cart.repository.ts
@@ -27,7 +27,6 @@ export class CartRepository {
       select: {
         id: true,
         buyerId: true,
-        quantity: true,
         createdAt: true,
         updatedAt: true,
         items: {
@@ -51,6 +50,8 @@ export class CartRepository {
                 discountEndTime: true,
                 createdAt: true,
                 updatedAt: true,
+                reviewsRating: true,
+                categoryId: true,
                 store: {
                   select: {
                     id: true,
@@ -174,6 +175,8 @@ export class CartRepository {
             discountEndTime: true,
             createdAt: true,
             updatedAt: true,
+            reviewsRating: true,
+            categoryId: true,
             store: {
               select: {
                 id: true,
@@ -209,7 +212,6 @@ export class CartRepository {
           select: {
             id: true,
             buyerId: true,
-            quantity: true,
             createdAt: true,
             updatedAt: true,
           },

--- a/src/domains/cart/cart.type.ts
+++ b/src/domains/cart/cart.type.ts
@@ -2,7 +2,6 @@
 export interface CartBase<TDate> {
   id: string;
   buyerId: string;
-  quantity: number;
   createdAt: TDate;
   updatedAt: TDate;
 }
@@ -48,6 +47,8 @@ interface ProductBase<TStocks, TStore, TTime> {
   discountEndTime: TTime | null;
   createdAt: TTime;
   updatedAt: TTime;
+  reviewsRating: number;
+  categoryId: string;
   store: TStore;
   stocks: TStocks[];
 }
@@ -64,6 +65,7 @@ export interface SizeRawData {
 
 interface SizeResponse {
   id: number;
+  name: string;
   size: {
     en: string;
     ko: string;


### PR DESCRIPTION
## 📝 변경 사항
### 1. 실제 응답과 swagger 문서 간 불일치 해결
- 장바구니 조회 응답 객체 cartBase type에서 quantity 삭제 ( 실제 응답에 포함되어있지 않음)
- 장바구니 조회 응답 객체 product 연관 데이터에서 reviewsRating, categoryId, content, isSoldOut 불일치 발견
  - reviewsRating과 categoryId는 사용하는거로 확인해서 추가, content는 미사용, isSoldOut은 프론트에서 직접 계산 후 추가 하는거로 확인되어 추가하지않음
- 장바구니 조회 응답 객체 product.store에서 detailAddress 필드 불일치
  - 응답 데이터엔 포함되나 장바구니 조회 부분에서 사용안함
- product.stock.size.name 불일치 - 추가

## 🔗 관련 이슈

## ✅ 체크리스트

- [x] 코드 작성 완료
- [x] 로컬에서 테스트 완료
- [x] Lint/Format 검사 통과
- [x] 타입 체크 통과
- [ ] 문서 업데이트 (필요시)

## 💬 참고사항
변경 사항은 아니고 확인된 사항으로
1. swagger 문서에는 get - /api/cart/{cartItemId} api가 있어서 구현했는데 실제로 프론트에서 호출하는 부분이 없었습니다.
일단 문서대로 남겨놓긴 했습니다.
2. 일단 1차적으로 수정했고 추후에 실제로 프론트랑 dev 환경에서 연결한 후에 수정 사항 확정 가능할 것 같아요 mapper에 작성한 주석을 일단 남겨두려고 합니다.
