### PR TITLE
유저 삭제 시 관련 데이터 삭제를 위한 prisma schema 변경 

### DIFF
--- a/prisma/migrations/20251212060526_add_cascade_delete_to_user/migration.sql
+++ b/prisma/migrations/20251212060526_add_cascade_delete_to_user/migration.sql
@@ -1,0 +1,77 @@
+-- DropForeignKey
+ALTER TABLE "cart_items" DROP CONSTRAINT "cart_items_productId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "carts" DROP CONSTRAINT "carts_buyerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "inquiries" DROP CONSTRAINT "inquiries_productId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "inquiries" DROP CONSTRAINT "inquiries_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "notifications" DROP CONSTRAINT "notifications_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "order_items" DROP CONSTRAINT "order_items_productId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "orders" DROP CONSTRAINT "orders_buyerId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "point_history" DROP CONSTRAINT "point_history_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "products" DROP CONSTRAINT "products_storeId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "replies" DROP CONSTRAINT "replies_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "reviews" DROP CONSTRAINT "reviews_productId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "reviews" DROP CONSTRAINT "reviews_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "stocks" DROP CONSTRAINT "stocks_productId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "products" ADD CONSTRAINT "products_storeId_fkey" FOREIGN KEY ("storeId") REFERENCES "stores"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "stocks" ADD CONSTRAINT "stocks_productId_fkey" FOREIGN KEY ("productId") REFERENCES "products"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "carts" ADD CONSTRAINT "carts_buyerId_fkey" FOREIGN KEY ("buyerId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "cart_items" ADD CONSTRAINT "cart_items_productId_fkey" FOREIGN KEY ("productId") REFERENCES "products"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "orders" ADD CONSTRAINT "orders_buyerId_fkey" FOREIGN KEY ("buyerId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "order_items" ADD CONSTRAINT "order_items_productId_fkey" FOREIGN KEY ("productId") REFERENCES "products"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "reviews" ADD CONSTRAINT "reviews_productId_fkey" FOREIGN KEY ("productId") REFERENCES "products"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "inquiries" ADD CONSTRAINT "inquiries_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "inquiries" ADD CONSTRAINT "inquiries_productId_fkey" FOREIGN KEY ("productId") REFERENCES "products"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "replies" ADD CONSTRAINT "replies_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "point_history" ADD CONSTRAINT "point_history_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "notifications" ADD CONSTRAINT "notifications_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,7 +143,7 @@ model Product {
 
   // FK
   storeId    String
-  store      Store    @relation(fields: [storeId], references: [id])
+  store      Store    @relation(fields: [storeId], references: [id], onDelete: Cascade) // 스토어 삭제 시 상품 삭제
   categoryId String
   category   Category @relation(fields: [categoryId], references: [id])
 
@@ -172,7 +172,7 @@ model Stock {
 
   // FK
   productId String
-  product   Product @relation(fields: [productId], references: [id])
+  product   Product @relation(fields: [productId], references: [id], onDelete: Cascade) // 상품 삭제 시 재고 삭제
   sizeId    Int
   size      Size    @relation(fields: [sizeId], references: [id])
 
@@ -191,7 +191,7 @@ model Cart {
 
   // FK
   buyerId String @unique
-  buyer   User   @relation(fields: [buyerId], references: [id])
+  buyer   User   @relation(fields: [buyerId], references: [id], onDelete: Cascade) // 유저 탈퇴 시 장바구니 삭제
 
   items CartItem[]
 
@@ -208,7 +208,7 @@ model CartItem {
   cartId    String
   cart      Cart    @relation(fields: [cartId], references: [id], onDelete: Cascade)
   productId String
-  product   Product @relation(fields: [productId], references: [id])
+  product   Product @relation(fields: [productId], references: [id], onDelete: Cascade) // 상품이 삭제되면 장바구니 내역에서도 삭제
   sizeId    Int
   size      Size    @relation(fields: [sizeId], references: [id])
 
@@ -232,7 +232,7 @@ model Order {
 
   // 비회원 주문에 대한 내용은 추후 확장
   buyerId String
-  buyer   User   @relation(fields: [buyerId], references: [id])
+  buyer   User   @relation(fields: [buyerId], references: [id], onDelete: Cascade) // 유저 탈퇴 시 주문 내역 삭제
 
   orderItems   OrderItem[]
   payment      Payment?
@@ -250,7 +250,7 @@ model OrderItem {
   orderId   String
   order     Order   @relation(fields: [orderId], references: [id], onDelete: Cascade)
   productId String
-  product   Product @relation(fields: [productId], references: [id])
+  product   Product @relation(fields: [productId], references: [id], onDelete: Cascade) // 상품 삭제 시 주문 상세 내역 삭제
   sizeId    Int
   size      Size    @relation(fields: [sizeId], references: [id])
 
@@ -286,9 +286,9 @@ model Review {
 
   // FK
   userId      String
-  user        User      @relation(fields: [userId], references: [id])
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade) // 유저 탈퇴 시 달린 리뷰 삭제
   productId   String
-  product     Product   @relation(fields: [productId], references: [id])
+  product     Product   @relation(fields: [productId], references: [id], onDelete: Cascade) // 상품 삭제 시 달린 리뷰 삭제
   orderItemId String    @unique // 리뷰는 특정 구매 건에 종속
   orderItem   OrderItem @relation(fields: [orderItemId], references: [id])
 
@@ -306,9 +306,9 @@ model Inquiry {
 
   // FK
   userId    String
-  user      User    @relation(fields: [userId], references: [id])
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade) // 유저 탈퇴 시 작성한 문의 삭제
   productId String
-  product   Product @relation(fields: [productId], references: [id])
+  product   Product @relation(fields: [productId], references: [id], onDelete: Cascade) // 상품 삭제 시 달린 문의 삭제
 
   reply Reply?
 
@@ -323,7 +323,7 @@ model Reply {
 
   // FK
   userId    String
-  user      User    @relation(fields: [userId], references: [id])
+  user      User    @relation(fields: [userId], references: [id], onDelete: Cascade) // 유저 탈퇴 시 작성한 답변 삭제
   inquiryId String  @unique
   inquiry   Inquiry @relation(fields: [inquiryId], references: [id], onDelete: Cascade)
 
@@ -352,7 +352,7 @@ model PointHistory {
 
   // FK
   userId  String
-  user    User    @relation(fields: [userId], references: [id])
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade) // 유저 탈퇴 시 포인트 내역 삭제
   orderId String? // 주문과 관련된 포인트일 경우
   order   Order?  @relation(fields: [orderId], references: [id])
 
@@ -368,7 +368,7 @@ model Notification {
 
   // FK
   userId String
-  user   User   @relation(fields: [userId], references: [id])
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade) // 유저 탈퇴 시 알림 삭제
 
   @@map("notifications")
 }


### PR DESCRIPTION
## **📝 변경 사항**

- `schema.prisma` 모델에 `onDelete: Cascade` 추가 (유저 삭제 시 관련 데이터 삭제)

### 모델 별 변경 사항

- Product
    - store: 스토어 삭제 시 상품 삭제
- Stock
    - product: 상품 삭제 시 재고 삭제
- Cart
    - buyer: 유저 탈퇴 시 장바구니 삭제
- CartItem
    - product: 상품 삭제 시 장바구니 내역 삭제
- Order
    - buyer: 유저 탈퇴 시 주문 내역 삭제
- OrderItem
    - product: 상품 삭제 시 주문 상세 내역 삭제
- Review
    - user: 유저 탈퇴 시 달린 리뷰 삭제
    - product: 상품 삭제 시 달린 리뷰 삭제
- Inquiry
    - user: 유저 탈퇴 시 작성한 문의 삭제
    - product: 상품 삭제 시 달린 문의 삭제
- Reply
    - user: 유저 탈퇴 시 작성한 답변 삭제
- PointHistory
    - user: 유저 탈퇴 시 포인트 내역 삭제
- Notification
    - user: 유저 탈퇴 시 알림 삭제

## **🔗 관련 이슈**

## **✅ 체크리스트**

- [x]  코드 작성 완료
- [ ]  로컬에서 테스트 완료
- [x]  Lint/Format 검사 통과
- [x]  타입 체크 통과
- [ ]  문서 업데이트 (필요 시)

## **💬 참고사항**

- **`npx prisma migrate deploy` 후 `npx prisma generate` 해주세요.**
    - **또는 `npx prisma migrate dev`만 하셔도 괜찮습니다.**
- 필요하지 않는 부분에 `onDelete: Cascade` 설정이 된 거면 지워주셔도 괜찮습니다.
