### PR TITLE
상품 정보 조회 시 review 반환 형식 수정

### DIFF
--- a/src/domains/product/product.dto.ts
+++ b/src/domains/product/product.dto.ts
@@ -99,7 +99,7 @@ export interface DetailProductResponse {
   discountStartTime: string | null;
   discountEndTime: string | null;
   reviewsCount: number;
-  reviews: ReviewStatsDto[];
+  reviews: ReviewStatsDto;
   inquiries: DetailInquiryDto[];
   category: CategoryResponseDto[];
   stocks: StocksDto[];

--- a/src/domains/product/product.mapper.ts
+++ b/src/domains/product/product.mapper.ts
@@ -116,7 +116,7 @@ export class ProductMapper {
       discountStartTime: product.discountStartTime?.toISOString() ?? null,
       discountEndTime: product.discountEndTime?.toISOString() ?? null,
       reviewsCount: product.reviewsCount ?? 0,
-      reviews: [stats],
+      reviews: stats,
       // inquiries 매핑
       inquiries: (product.inquiries ?? []).map((inquiry) => ({
         id: inquiry.id,


### PR DESCRIPTION
## 📝 변경 사항

**상품 상세 조회 응답 구조 변경: 프론트엔드 요구사항에 맞춰 reviews 필드의 데이터 타입을 배열(ReviewStatsDto[])에서 단일 객체(ReviewStatsDto)로 변경하였습니다.**

- product.dto.ts 수정: DetailProductResponse 인터페이스 내 reviews 타입을 객체로 수정하였습니다.
- product.mapper.ts 수정: toDetailResponse 메서드에서 계산된 리뷰 통계(stats)를 배열에 담지 않고 필드에 직접 할당하도록 매핑 로직을 변경하였습니다.

## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 연결해주세요 -->
<!-- Closes #123 또는 Related to #123 -->

## ✅ 체크리스트

- [x] 코드 작성 완료
- [x] 로컬에서 테스트 완료
- [x] Lint/Format 검사 통과
- [x] 타입 체크 통과
- [ ] 문서 업데이트 (필요시)

## 💬 참고사항

- 금일 학습 QnA에 올라온 내용입니다.
