### PR TITLE
유저 응답 적립률 수정 & 유저 수정 시 이미지 url 추가 

### DIFF
--- a/__tests__/unit/user.service.test.ts
+++ b/__tests__/unit/user.service.test.ts
@@ -157,15 +157,15 @@ describe('UserService 유닛 테스트', () => {
     it('이미지만 변경하는 경우 성공', async () => {
       // --- 준비 (Arrange) ---
       const user = createUserWithGradeMock({ id: userId });
-      const updateData = { currentPassword: 'current1234' };
       const imageUrl = 'https://example.com/new-image.jpg';
+      const updateData = { currentPassword: 'current1234', imageUrl };
       const updatedUser = createUserWithGradeMock({ id: userId, image: imageUrl });
 
       userRepository.findById.mockResolvedValue(user);
       userRepository.update.mockResolvedValue(updatedUser);
 
       // --- 실행 (Act) ---
-      const result = await userService.updateMe(userId, updateData, imageUrl);
+      const result = await userService.updateMe(userId, updateData);
 
       // --- 검증 (Assert) ---
       expect(userRepository.update).toHaveBeenCalledWith(userId, { image: imageUrl });
@@ -192,8 +192,8 @@ describe('UserService 유닛 테스트', () => {
     it('이름과 이미지를 동시에 변경하는 경우 성공', async () => {
       // --- 준비 (Arrange) ---
       const user = createUserWithGradeMock({ id: userId });
-      const updateData = { currentPassword: 'current1234', name: '새로운 이름' };
       const imageUrl = 'https://example.com/new-image.jpg';
+      const updateData = { currentPassword: 'current1234', name: '새로운 이름', imageUrl };
       const updatedUser = createUserWithGradeMock({
         id: userId,
         name: '새로운 이름',
@@ -204,7 +204,7 @@ describe('UserService 유닛 테스트', () => {
       userRepository.update.mockResolvedValue(updatedUser);
 
       // --- 실행 (Act) ---
-      const result = await userService.updateMe(userId, updateData, imageUrl);
+      const result = await userService.updateMe(userId, updateData);
 
       // --- 검증 (Assert) ---
       expect(userRepository.update).toHaveBeenCalledWith(userId, {

--- a/src/domains/auth/auth.service.ts
+++ b/src/domains/auth/auth.service.ts
@@ -46,7 +46,7 @@ export class AuthService {
         grade: {
           id: user.grade.id,
           name: user.grade.name,
-          rate: user.grade.rate,
+          rate: user.grade.rate * 100,
           minAmount: user.grade.minAmount,
         },
       },

--- a/src/domains/user/user.mapper.ts
+++ b/src/domains/user/user.mapper.ts
@@ -18,7 +18,7 @@ export const toUserResponse = (user: UserWithGrade): UserResponseDto => {
     grade: {
       id: user.grade.id,
       name: user.grade.name,
-      rate: user.grade.rate,
+      rate: user.grade.rate * 100,
       minAmount: user.grade.minAmount,
     },
   };

--- a/src/domains/user/user.schema.ts
+++ b/src/domains/user/user.schema.ts
@@ -11,6 +11,7 @@ export const updateUserSchema = z.object({
   name: z.string().min(1, '이름을 입력해주세요.').optional(),
   password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.').optional(),
   currentPassword: z.string().min(1, '현재 비밀번호를 입력해주세요.'),
+  imageUrl: z.string().url().optional(),
 });
 
 export type CreateUserDto = z.infer<typeof createUserSchema>;

--- a/src/domains/user/user.service.ts
+++ b/src/domains/user/user.service.ts
@@ -45,8 +45,8 @@ export class UserService {
     return toUserResponse(user);
   }
 
-  async updateMe(userId: string, dto: UpdateUserDto, imageUrl?: string): Promise<UserResponseDto> {
-    const { name, password, currentPassword } = dto;
+  async updateMe(userId: string, dto: UpdateUserDto): Promise<UserResponseDto> {
+    const { name, password, currentPassword, imageUrl } = dto;
 
     if (!name && !password && !imageUrl) {
       throw new BadRequestError('수정할 내용이 없습니다.');


### PR DESCRIPTION
## 📝 변경 사항
                                                                                                                        
  1. 유저 정보 수정 시 이미지 URL 추가                                                                                                                                                                                                                                                            
  - updateUserSchema에 imageUrl 필드 추가                                                                                                                                                                                                                                         
                                                                                                                                                      
  2. 등급(Grade) 적립률 표시 형식 수정                                                                                                                                                                                                                                                                     
  - auth.service.ts: 로그인 응답에서 grade.rate 값을 * 100으로 변환 후 유저 정보 응답에서도 동일하게 grade.rate * 100 적용                                                                               
                                                                                                                                                      
  3. 테스트 코드 수정                                                                                                                                                                                                                                                                          
  - user.service.test.ts: updateMe 호출 방식을 imageUrl을 updateData 객체 내부에 포함 
  
테스트 코드는 타입 에러로 인해 같이 수정하게 되었습니다 ! 

## 🔗 관련 이슈

## ✅ 체크리스트

- [x] 코드 작성 완료
- [x] 로컬에서 테스트 완료
- [x] Lint/Format 검사 통과
- [x] 타입 체크 통과
- [ ] 문서 업데이트 (필요시)

## 💬 참고사항