### PR TITLE
상품 상세 페이지 리뷰 평점 평균값 반환

### DIFF
--- a/src/domains/product/product.mapper.ts
+++ b/src/domains/product/product.mapper.ts
@@ -69,13 +69,12 @@ export class ProductMapper {
       rate3Length: 0,
       rate4Length: 0,
       rate5Length: 0,
-      sumScore: 0,
+      sumScore: product.reviewsRating ?? 0, // DB의 동기화된 값을 그대로 할당
     };
 
+    // 별점별 개수(분포도)는 DB에 없으므로 여전히 계산이 필요함
     if (product.reviews && product.reviews.length > 0) {
-      // product가 정확히 타이핑되면 review의 타입도 자동으로 추론됩니다.
       product.reviews.forEach((review) => {
-        stats.sumScore += review.rating;
         switch (review.rating) {
           case 1:
             stats.rate1Length++;


### PR DESCRIPTION
## 📝 변경 사항

- 상품 상세 조회 리뷰 평점 매핑 로직 최적화: `ProductMapper.toDetailResponse`에서 리뷰 합산 값(`sumScore`)을 매번 루프를 돌며 수동으로 계산하던 로직을 제거했습니다.
- DB 데이터 활용: [이전에 올린 PR](https://github.com/nb04-part4-team2/nb04-codiit-team2/pull/162) 변경 사항의 `ReviewRepository`에서 트랜잭션을 통해 실시간으로 동기화되고 있는 `product.reviewsRating` 값을 `sumScore` 필드에 직접 매핑하도록 변경하여 성능과 데이터 정합성을 높였습니다.

## 🔗 관련 이슈

- #166 

## ✅ 체크리스트

- [x] 코드 작성 완료
- [ ] 로컬에서 테스트 완료
- [x] Lint/Format 검사 통과
- [x] 타입 체크 통과
- [ ] 문서 업데이트 (필요시)

## 💬 참고사항
