### PR TITLE
fix: CI 워크플로우에 deploy 브랜치 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, deploy]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, deploy]
 
 jobs:
   lint-and-typecheck:


### PR DESCRIPTION
본문:
  ## 📝 변경 사항

  deploy 브랜치에서 CI가 실행되도록 트리거 추가
  - `ci.yml`에 deploy 브랜치 추가 (push, pull_request)
  - deploy 브랜치 push → CI 실행 → deploy-dev.yml 자동 트리거

  ## 🔗 관련 이슈


  ## ✅ 체크리스트

  - [x] 코드 작성 완료
  - [x] 로컬에서 테스트 완료
  - [x] Lint/Format 검사 통과
  - [x] 타입 체크 통과
  - [ ] 문서 업데이트 (필요시)

  ## 💬 참고사항

  deploy 브랜치 자동 배포를 위한 필수 수정