### PR TITLE
fix: deploy-dev.yml을 push 트리거로 변경

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,6 +1,9 @@
 name: Deploy to AWS (Deploy Branch)
 
 on:
+  push:
+    branches:
+      - deploy
   workflow_dispatch:
     inputs:
       environment:
@@ -10,12 +13,6 @@ on:
         options:
           - development
         default: development
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
-    branches:
-      - deploy
 
 env:
   AWS_REGION: ap-northeast-2
@@ -29,9 +26,6 @@ env:
 
 jobs:
   deploy:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## 📝 변경 사항

  workflow_run 대신 push 트리거로 변경
  - deploy 브랜치 push 시 즉시 배포 시작
  - main 브랜치 의존성 제거

  ## 🔗 관련 이슈

  ## ✅ 체크리스트

  - [x] 코드 작성 완료
  - [x] 로컬에서 테스트 완료
  - [x] Lint/Format 검사 통과
  - [x] 타입 체크 통과

  ## 💬 참고사항

  deploy 브랜치 push → deploy-dev.yml 즉시 실행