### PR TITLE
auth 유닛 테스트 구현

### DIFF
--- a/__tests__/mocks/auth.mock.ts
+++ b/__tests__/mocks/auth.mock.ts
@@ -1,0 +1,61 @@
+import type { LoginDto } from '@/domains/auth/auth.schema.js';
+
+// ============================================
+// LoginDto Mock (로그인 요청 DTO)
+// ============================================
+export const createLoginInputMock = (overrides: Partial<LoginDto> = {}): LoginDto => ({
+  email: 'test@example.com',
+  password: 'test1234',
+  ...overrides,
+});
+
+// ============================================
+// Login Response Mock (로그인 응답)
+// ============================================
+export const createLoginResponseMock = (overrides: Partial<LoginResponseMock> = {}) => ({
+  accessToken: 'mock-access-token',
+  refreshToken: 'mock-refresh-token',
+  user: {
+    id: 'user-id-1',
+    email: 'test@example.com',
+    name: '테스트 유저',
+    type: 'BUYER' as const,
+    point: 0,
+    image: null,
+    grade: {
+      id: 'grade_green',
+      name: 'green',
+      rate: 5,
+      minAmount: 0,
+    },
+    ...overrides.user,
+  },
+  ...overrides,
+});
+
+interface LoginResponseMock {
+  accessToken: string;
+  refreshToken: string;
+  user: {
+    id: string;
+    email: string;
+    name: string;
+    type: 'BUYER' | 'SELLER';
+    point: number;
+    image: string | null;
+    grade: {
+      id: string;
+      name: string;
+      rate: number;
+      minAmount: number;
+    };
+  };
+}
+
+// ============================================
+// Refresh Response Mock (토큰 갱신 응답)
+// ============================================
+export const createRefreshResponseMock = (overrides: { accessToken?: string } = {}) => ({
+  accessToken: 'new-mock-access-token',
+  ...overrides,
+});

--- a/__tests__/unit/auth.service.test.ts
+++ b/__tests__/unit/auth.service.test.ts
@@ -1,0 +1,155 @@
+import { jest, beforeEach, afterEach, describe, it, expect } from '@jest/globals';
+import { mockDeep, DeepMockProxy } from 'jest-mock-extended';
+import { createUserWithGradeMock } from '../mocks/user.mock.js';
+import { createLoginInputMock } from '../mocks/auth.mock.js';
+import { UnauthorizedError } from '@/common/utils/errors.js';
+import type { UserRepository } from '@/domains/user/user.repository.js';
+
+// JWT util mock
+const mockGenerateAccessToken = jest.fn().mockReturnValue('mock-access-token');
+const mockGenerateRefreshToken = jest.fn().mockReturnValue('mock-refresh-token');
+const mockVerifyRefreshToken = jest.fn();
+
+jest.unstable_mockModule('@/common/utils/jwt.util.js', () => ({
+  generateAccessToken: mockGenerateAccessToken,
+  generateRefreshToken: mockGenerateRefreshToken,
+  verifyRefreshToken: mockVerifyRefreshToken,
+}));
+
+// bcrypt mock
+const mockCompare = jest.fn<(data: string, encrypted: string) => Promise<boolean>>();
+jest.unstable_mockModule('bcrypt', () => ({
+  default: {
+    compare: mockCompare,
+  },
+}));
+
+// 동적 import (mock 설정 후)
+const { AuthService } = await import('@/domains/auth/auth.service.js');
+
+describe('AuthService 유닛 테스트', () => {
+  let authService: InstanceType<typeof AuthService>;
+  let userRepository: DeepMockProxy<UserRepository>;
+
+  const userId = 'user-id-1';
+
+  beforeEach(() => {
+    // 의존성 주입
+    userRepository = mockDeep<UserRepository>();
+    authService = new AuthService(userRepository);
+
+    // 기본 mock 설정
+    mockCompare.mockResolvedValue(true);
+    mockGenerateAccessToken.mockReturnValue('mock-access-token');
+    mockGenerateRefreshToken.mockReturnValue('mock-refresh-token');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // 로그인
+  describe('login', () => {
+    it('로그인 성공', async () => {
+      // --- 준비 (Arrange) ---
+      const inputData = createLoginInputMock();
+      const user = createUserWithGradeMock({ email: inputData.email });
+
+      userRepository.findByEmail.mockResolvedValue(user);
+
+      // --- 실행 (Act) ---
+      const result = await authService.login(inputData);
+
+      // --- 검증 (Assert) ---
+      expect(userRepository.findByEmail).toHaveBeenCalledWith(inputData.email);
+      expect(mockCompare).toHaveBeenCalledWith(inputData.password, user.password);
+      expect(mockGenerateAccessToken).toHaveBeenCalledWith(user.id, user.type);
+      expect(mockGenerateRefreshToken).toHaveBeenCalledWith(user.id, user.type);
+      expect(result.accessToken).toBe('mock-access-token');
+      expect(result.refreshToken).toBe('mock-refresh-token');
+      expect(result.user.email).toBe(inputData.email);
+    });
+
+    it('존재하지 않는 이메일인 경우 UnauthorizedError 발생', async () => {
+      // --- 준비 (Arrange) ---
+      const inputData = createLoginInputMock({ email: 'notfound@example.com' });
+
+      userRepository.findByEmail.mockResolvedValue(null);
+
+      // --- 실행 및 검증 (Act & Assert) ---
+      await expect(authService.login(inputData)).rejects.toThrow(UnauthorizedError);
+      expect(mockCompare).not.toHaveBeenCalled();
+      expect(mockGenerateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('비밀번호가 틀린 경우 UnauthorizedError 발생', async () => {
+      // --- 준비 (Arrange) ---
+      const inputData = createLoginInputMock({ password: 'wrongpassword' });
+      const user = createUserWithGradeMock({ email: inputData.email });
+
+      userRepository.findByEmail.mockResolvedValue(user);
+      mockCompare.mockResolvedValue(false);
+
+      // --- 실행 및 검증 (Act & Assert) ---
+      await expect(authService.login(inputData)).rejects.toThrow(UnauthorizedError);
+      expect(mockGenerateAccessToken).not.toHaveBeenCalled();
+    });
+  });
+
+  // 토큰 갱신
+  describe('refresh', () => {
+    it('토큰 갱신 성공', async () => {
+      // --- 준비 (Arrange) ---
+      const refreshToken = 'valid-refresh-token';
+      const user = createUserWithGradeMock({ id: userId });
+
+      mockVerifyRefreshToken.mockReturnValue({ userId, type: 'BUYER' });
+      userRepository.findById.mockResolvedValue(user);
+
+      // --- 실행 (Act) ---
+      const result = await authService.refresh(refreshToken);
+
+      // --- 검증 (Assert) ---
+      expect(mockVerifyRefreshToken).toHaveBeenCalledWith(refreshToken);
+      expect(userRepository.findById).toHaveBeenCalledWith(userId);
+      expect(mockGenerateAccessToken).toHaveBeenCalledWith(user.id, user.type);
+      expect(result.accessToken).toBe('mock-access-token');
+    });
+
+    it('사용자가 존재하지 않는 경우 UnauthorizedError 발생', async () => {
+      // --- 준비 (Arrange) ---
+      const refreshToken = 'valid-refresh-token';
+
+      mockVerifyRefreshToken.mockReturnValue({ userId, type: 'BUYER' });
+      userRepository.findById.mockResolvedValue(null);
+
+      // --- 실행 및 검증 (Act & Assert) ---
+      await expect(authService.refresh(refreshToken)).rejects.toThrow(UnauthorizedError);
+      expect(mockGenerateAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('유효하지 않은 토큰인 경우 에러 발생', async () => {
+      // --- 준비 (Arrange) ---
+      const invalidToken = 'invalid-token';
+
+      mockVerifyRefreshToken.mockImplementation(() => {
+        throw new Error('Invalid token');
+      });
+
+      // --- 실행 및 검증 (Act & Assert) ---
+      await expect(authService.refresh(invalidToken)).rejects.toThrow();
+      expect(userRepository.findById).not.toHaveBeenCalled();
+    });
+  });
+
+  // 로그아웃
+  describe('logout', () => {
+    it('로그아웃 성공', async () => {
+      // --- 실행 (Act) ---
+      const result = await authService.logout();
+
+      // --- 검증 (Assert) ---
+      expect(result.message).toBe('로그아웃 되었습니다.');
+    });
+  });
+});

--- a/__tests__/unit/user.service.test.ts
+++ b/__tests__/unit/user.service.test.ts
@@ -19,8 +19,8 @@ import bcrypt from 'bcrypt';
 describe('UserService 유닛 테스트', () => {
   let userService: UserService;
   let userRepository: DeepMockProxy<UserRepository>;
-  let hashSpy: jest.SpiedFunction<typeof bcrypt.hash>;
-  let compareSpy: jest.SpiedFunction<typeof bcrypt.compare>;
+  let hashSpy: jest.MockedFunction<(data: string, saltOrRounds: number) => Promise<string>>;
+  let compareSpy: jest.MockedFunction<(data: string, encrypted: string) => Promise<boolean>>;
 
   const userId = 'user-id-1';
 
@@ -31,11 +31,11 @@ describe('UserService 유닛 테스트', () => {
     userService = new UserService(userRepository);
 
     // bcrypt spyOn mock
-    hashSpy = jest.spyOn(bcrypt, 'hash') as jest.SpiedFunction<typeof bcrypt.hash>;
-    compareSpy = jest.spyOn(bcrypt, 'compare') as jest.SpiedFunction<typeof bcrypt.compare>;
+    hashSpy = jest.spyOn(bcrypt, 'hash') as typeof hashSpy;
+    compareSpy = jest.spyOn(bcrypt, 'compare') as typeof compareSpy;
 
-    hashSpy.mockResolvedValue('hashed-password' as never);
-    compareSpy.mockResolvedValue(true as never);
+    hashSpy.mockResolvedValue('hashed-password');
+    compareSpy.mockResolvedValue(true);
   });
 
   // 각 테스트가 끝난 후 모든 모의(mock)를 원래대로 복원
@@ -138,7 +138,7 @@ describe('UserService 유닛 테스트', () => {
       const updateData = updateUserInputMock();
 
       userRepository.findById.mockResolvedValue(user);
-      compareSpy.mockResolvedValue(false as never);
+      compareSpy.mockResolvedValue(false);
 
       // --- 실행 및 검증 (Act & Assert) ---
       await expect(userService.updateMe(userId, updateData)).rejects.toThrow(UnauthorizedError);

--- a/src/domains/auth/auth.container.ts
+++ b/src/domains/auth/auth.container.ts
@@ -1,0 +1,9 @@
+import { AuthController } from './auth.controller.js';
+import { AuthService } from './auth.service.js';
+import { UserRepository } from '@/domains/user/user.repository.js';
+
+// 의존성 주입
+const userRepository = new UserRepository();
+const authService = new AuthService(userRepository);
+
+export const authController = new AuthController(authService);

--- a/src/domains/auth/auth.controller.ts
+++ b/src/domains/auth/auth.controller.ts
@@ -5,8 +5,8 @@ import { UnauthorizedError } from '@/common/utils/errors.js';
 export class AuthController {
   private authService: AuthService;
 
-  constructor() {
-    this.authService = new AuthService();
+  constructor(authService: AuthService) {
+    this.authService = authService;
   }
 
   login = async (req: Request, res: Response): Promise<void> => {

--- a/src/domains/auth/auth.router.ts
+++ b/src/domains/auth/auth.router.ts
@@ -1,11 +1,11 @@
 import { Router } from 'express';
-import { AuthController } from './auth.controller.js';
+import { authController } from './auth.container.js';
 import { asyncHandler } from '@/common/middlewares/asyncHandler.js';
 import { authenticate } from '@/common/middlewares/auth.middleware.js';
 import { validate } from '@/common/middlewares/validate.middleware.js';
 import { loginSchema } from './auth.schema.js';
+
 const router = Router();
-const authController = new AuthController();
 
 router.post('/login', validate(loginSchema, 'body'), asyncHandler(authController.login));
 router.post('/refresh', asyncHandler(authController.refresh));

--- a/src/domains/auth/auth.service.ts
+++ b/src/domains/auth/auth.service.ts
@@ -11,8 +11,8 @@ import { UserRepository } from '@/domains/user/user.repository.js';
 export class AuthService {
   private userRepository: UserRepository;
 
-  constructor() {
-    this.userRepository = new UserRepository();
+  constructor(userRepository: UserRepository) {
+    this.userRepository = userRepository;
   }
 
   async login(dto: unknown) {


### PR DESCRIPTION
## 📝 변경 사항

1. Auth 도메인에 Container 패턴 적용
                                _ mock 데이터 주입 위함

-> auth 파일 부분에서 수정된 부분들은 다 container 패턴 적용으로 인한 수정 

2.  Auth 유닛테스트 구현

- 테스트 코드 타입 안전성 개선하기 위해 `jest.fn()`에 타입을 명시하여 `as never` 우회 패턴 제거 
     =>   __tests__/unit/user.service.test.ts 파일 수정 포함

## 🔗 관련 이슈

Closes #193 

## ✅ 체크리스트

- [x] 코드 작성 완료
- [x] 로컬에서 테스트 완료
- [x] Lint/Format 검사 통과
- [x] 타입 체크 통과
- [ ] 문서 업데이트 (필요시)

## 💬 참고사항

<!-- 리뷰어에게 알려주고 싶은 내용이나 특별히 확인해야 할 부분 -->
<!-- db 스키마 변동, 패키지 변동 사항 꼭 남겨주세요 -->
