### PR TITLE
fix: 배포 워크플로우 수정

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -280,8 +280,11 @@ jobs:
 
             echo "Target health: $HEALTH ($i/20)"
 
-            if [[ "$HEALTH" == "healthy" ]]; then
-              echo "✅ Target is healthy!"
+            # Blue-Green 배포에서 비활성 Target Group은 'unused' 상태가 정상
+            # ALB가 해당 TG를 사용하지 않으므로 Health Check가 실행되지 않음
+            # 'unused'는 배포 실패가 아니라 "대기 중" 상태를 의미
+            if [[ "$HEALTH" == "healthy" ]] || [[ "$HEALTH" == "unused" ]]; then
+              echo "✅ Target is ready! (Status: $HEALTH)"
               exit 0
             fi
 
@@ -374,3 +377,35 @@ jobs:
           echo "디버깅 정보:"
           echo "  Instance ID: ${{ steps.ec2-setup.outputs.instance_id }}"
           echo "  Public IP: ${{ steps.get-ip.outputs.public_ip }}"
+
+      # ============================================
+      # Discord 알림
+      # ============================================
+      - name: Discord 배포 성공 알림
+        if: success()
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          title: "✅ 배포 성공!"
+          description: |
+            **브랜치**: ${{ github.ref_name }}
+            **커밋**: ${{ github.event.head_commit.message }}
+            **작성자**: ${{ github.actor }}
+            **환경**: ${{ steps.detect.outputs.target_env }}
+            **인스턴스**: ${{ steps.ec2-setup.outputs.instance_id }}
+            **워크플로우**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          color: 0x00FF00
+
+      - name: Discord 배포 실패 알림
+        if: failure()
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          title: "❌ 배포 실패!"
+          description: |
+            **브랜치**: ${{ github.ref_name }}
+            **커밋**: ${{ github.event.head_commit.message }}
+            **작성자**: ${{ github.actor }}
+            **환경**: ${{ steps.detect.outputs.target_env || 'unknown' }}
+            **로그**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          color: 0xFF0000


### PR DESCRIPTION
## 📝 변경 사항

  ### 1. GitHub Actions 워크플로우 개선
  - **Health Check 로직 수정**: Blue-Green 배포 시 `unused` 상태를 정상으로 인식하도록 개선
  - **Discord 배포 알림 추가**: 배포 성공/실패 시 Discord 채널로 자동 알림 전송

  ### 2. 주요 수정 파일
  - `.github/workflows/deploy-dev.yml`
    - Target Health 체크 시 `healthy` 또는 `unused` 모두 허용
    - 주석 추가로 `unused` 허용 이유 명시
    - Discord 알림 step 추가 (성공/실패 분기)

  ## 🔗 관련 이슈

  - Blue-Green 배포 시 비활성 Target Group의 `unused` 상태로 인한 배포 실패 해결
  - 배포 알림 자동화

  ## ✅ 체크리스트

  - [x] 코드 작성 완료
  - [x] 로컬에서 테스트 완료
  - [x] Lint/Format 검사 통과
  - [x] 타입 체크 통과
  - [ ] 문서 업데이트 (필요시)

  ## 💬 참고사항

  ### Health Check 로직 변경
  - **변경 전**: `healthy` 상태만 허용 → 비활성 TG 등록 시 실패
  - **변경 후**: `healthy` 또는 `unused` 허용 → Blue-Green 정상 동작

  ### Discord 알림
  - GitHub Secret `DISCORD_WEBHOOK_URL` 추가 완료
  - 알림 포함 정보: 브랜치, 커밋, 작성자, 환경(blue/green), 인스턴스 ID, 워크플로우 링크

  ### 배포 영향
  - 워크플로우 수정사항은 `deploy` 브랜치 merge 후 적용됨
  - 다음 배포부터 개선된 로직 및 Discord 알림 동작