### PR TITLE
fix: Free Tier 대상 인스턴스 타입 t3.micro로 변경

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -94,7 +94,7 @@ jobs:
 
             INSTANCE_ID=$(aws ec2 run-instances \
               --image-id ${{ secrets.GOLDEN_AMI_ID }} \
-              --instance-type t2.micro \
+              --instance-type t3.micro \
               --key-name ${{ env.KEY_NAME }} \
               --security-group-ids ${{ env.SECURITY_GROUP_ID }} \
               --subnet-id ${{ env.SUBNET_ID }} \


### PR DESCRIPTION
## 📝 변경 사항

  AWS Free Tier 정책 변경에 따라 EC2 인스턴스 타입을 `t2.micro`에서 `t3.micro`로 변경

  - `t2.micro`는 더 이상 Free Tier 대상이 아님
  - `t3.micro`는 Free Tier 대상이며 성능도 향상됨

  ## 🔗 관련 이슈

  배포 워크플로우 실패 이슈 해결
  - InvalidParameterCombination 에러 수정

  ## ✅ 체크리스트

  - [x] 코드 작성 완료
  - [x] 로컬에서 테스트 완료
  - [x] Lint/Format 검사 통과
  - [x] 타입 체크 통과
  - [ ] 문서 업데이트 (필요시)

  ## 💬 참고사항

  - IAM Instance Profile `CodiitEC2Role` 수정 완료
  - `codiit-deploy-user`에 `iam:PassRole` 권한 추가 완료
 