### PR TITLE
fix: Store API 할인 로직 수정 및 성능 최적화

### DIFF
--- a/__tests__/unit/store.service.test.ts
+++ b/__tests__/unit/store.service.test.ts
@@ -216,6 +216,36 @@ describe('StoreService 유닛 테스트', () => {
       // --- 검증 (Assert) ---
       expect(result.products[0].isDiscount).toBe(true);
     });
+
+    it('할인율은 있지만 기간이 설정되지 않은 경우(상시 할인) isDiscount가 true', async () => {
+      // --- 준비 (Arrange) ---
+      const store = createStoreMock({ id: storeId, userId });
+      const mockProducts = [
+        {
+          id: 'product-1',
+          image: 'image1.jpg',
+          name: '상시 할인 상품',
+          price: 10000,
+          isSoldOut: false,
+          discountRate: 5,
+          discountStartTime: null, // 기간 없음
+          discountEndTime: null, // 기간 없음
+          createdAt: new Date(),
+          stocks: [{ quantity: 10 }],
+        },
+      ];
+
+      storeRepository.findByUserId.mockResolvedValue(store);
+      storeRepository.findProductsWithStock.mockResolvedValue(mockProducts);
+      storeRepository.countProducts.mockResolvedValue(1);
+
+      // --- 실행 (Act) ---
+      const result = await storeService.getMyStoreProducts(userId, {});
+
+      // --- 검증 (Assert) ---
+      expect(result.products[0].isDiscount).toBe(true);
+      expect(result.products[0].price).toBe(10000); // 원가 그대로
+    });
   });
 
   // 스토어 수정

--- a/src/domains/store/store.service.ts
+++ b/src/domains/store/store.service.ts
@@ -77,10 +77,8 @@ export class StoreService {
       const stock = product.stocks.reduce((sum, s) => sum + s.quantity, 0);
       const isDiscount =
         product.discountRate > 0 &&
-        product.discountStartTime !== null &&
-        product.discountEndTime !== null &&
-        product.discountStartTime <= now &&
-        now <= product.discountEndTime;
+        (!product.discountStartTime || now >= product.discountStartTime) &&
+        (!product.discountEndTime || now <= product.discountEndTime);
 
       return {
         id: product.id,


### PR DESCRIPTION
## 📝 변경 사항

  ### 버그 수정
  - 할인율은 있지만 기간이 null인 경우(상시 할인) `isDiscount`가 false로 반환되던 버그 수정
  - Product 도메인과 동일한 로직으로 통일 (`!field || condition` 패턴 적용)

  ### 성능 최적화
  - `new Date()` 객체를 map 외부로 이동하여 성능 개선
  - 모든 상품을 동일한 시점 기준으로 할인 판정 (할인 판정 시점 일관성 확보)

  ### 테스트 추가
  - 유닛 테스트 1개: 상시 할인 케이스
  - 통합 테스트 3개: 상시 할인, 기간 할인, 할인 없음

  ## 🔗 관련 이슈

  - Related to  #213 

  ## ✅ 체크리스트

  - [x] 코드 작성 완료
  - [x] 로컬에서 테스트 완료 (유닛 19개, 통합 34개 통과)
  - [x] Lint/Format 검사 통과
  - [x] 타입 체크 통과
  - [ ] 문서 업데이트 (필요시)

  ## 💬 참고사항

  **수정된 할인 로직:**
  ```typescript
  const isDiscount =
    product.discountRate > 0 &&
    (!product.discountStartTime || now >= product.discountStartTime) &&
    (!product.discountEndTime || now <= product.discountEndTime);

  - discountStartTime과 discountEndTime이 null이면 상시 할인으로 처리
  - Product 도메인의 검증된 패턴을 Store 도메인에 적용