### PR TITLE
유저 포인트 수정 

### DIFF
--- a/__tests__/mocks/auth.mock.ts
+++ b/__tests__/mocks/auth.mock.ts
@@ -20,7 +20,7 @@ export const createLoginResponseMock = (overrides: Partial<LoginResponseMock> = 
     email: 'test@example.com',
     name: '테스트 유저',
     type: 'BUYER' as const,
-    point: 0,
+    points: 0,
     image: null,
     grade: {
       id: 'grade_green',

--- a/src/domains/auth/auth.service.ts
+++ b/src/domains/auth/auth.service.ts
@@ -41,7 +41,7 @@ export class AuthService {
         email: user.email,
         name: user.name,
         type: user.type,
-        point: user.point,
+        points: user.point,
         image: user.image,
         grade: {
           id: user.grade.id,


### PR DESCRIPTION
## 📝 변경 사항

프론트엔드에서 points 기댓값에 따라 원래는 point -> points로 변경하려고 했으나
DB를 직접 수정하는 것보다 로그인의 응답 값을 points로 수정하는 방향이 여러 방면에서 더 나은 것 같아서 우선 이렇게 진행하였습니다 ! 

1. 프론트엔드의 기댓값에 일치함  -> 로그인 응답 부분에서 프론트엔드가 기대하는 값이 points임.
2. 따로 다른 도메인이 수정할 필요가 없음 -> point를 쓰고 있는 주문에서는 db 수정 사항이 없기에 그대로 point 사용해도 문제 발생 없음

  DB 컬럼: point (그대로 유지)
           ↓
  **마이페이지**  user.mapper.ts: points: user.point  → 응답은 "points" 
  **로그인 응답** auth.service.ts: point: user.point  → 응답은 "point" (불일치) 


## 🔗 관련 이슈

## ✅ 체크리스트

- [x] 코드 작성 완료
- [x] 로컬에서 테스트 완료
- [x] Lint/Format 검사 통과
- [x] 타입 체크 통과
- [ ] 문서 업데이트 (필요시)

## 💬 참고사항

다른 더 좋은 방법이 있으면 알려주시면 감사하겠습니다 -! 🙇‍♂️
