### PR TITLE
fix: Store 도메인 공백 검증 추가

### DIFF
--- a/src/domains/store/store.schema.ts
+++ b/src/domains/store/store.schema.ts
@@ -33,10 +33,11 @@ export type StoreProductQuery = z.infer<typeof storeProductQuerySchema>;
 const storeBaseSchema = z.object({
   name: z
     .string()
+    .trim()
     .min(1, '스토어 이름을 입력하세요.')
     .max(100, '스토어 이름은 최대 100자까지 가능합니다.'),
-  address: z.string().min(1, '주소를 입력하세요.'),
-  detailAddress: z.string().min(1, '상세 주소를 입력하세요.').optional(),
+  address: z.string().trim().min(1, '주소를 입력하세요.'),
+  detailAddress: z.string().trim().min(1, '상세 주소를 입력하세요.').optional(),
   phoneNumber: z
     .string()
     .min(1, '전화번호를 입력하세요.')
@@ -46,6 +47,7 @@ const storeBaseSchema = z.object({
     ),
   content: z
     .string()
+    .trim()
     .min(10, '스토어 소개는 최소 10자 이상 입력하세요.')
     .max(300, '스토어 소개는 최대 300자까지 가능합니다.'),
   image: z.string().optional(),
@@ -61,7 +63,6 @@ export type CreateStoreBody = z.infer<typeof createStoreSchema>;
 
 // ============================================
 // Request Body - Update Store
-// base.partial() + image nullable 오버라이드 (이미지 삭제 가능)
 // ============================================
 
 export const updateStoreSchema = storeBaseSchema


### PR DESCRIPTION
## 📝 변경 사항

  Store API 공백 문자열 검증

  - name, address, detailAddress, content 필드에 .trim() 추가
  - 공백만 입력 시 유효성 검증 실패하도록 추가
  -  사이드 이펙트 없음 확인

## 🔗 관련 이슈

<!-- 관련 이슈가 있다면 연결해주세요 -->
  - Related to #246 

## ✅ 체크리스트

- [x] 코드 작성 완료
- [x] 로컬에서 테스트 완료
- [x] Lint/Format 검사 통과
- [x] 타입 체크 통과
- [ ] 문서 업데이트 (필요시)

## 💬 참고사항

<!-- 리뷰어에게 알려주고 싶은 내용이나 특별히 확인해야 할 부분 -->
<!-- db 스키마 변동, 패키지 변동 사항 꼭 남겨주세요 -->
