### PR TITLE
주문 swagger 파일 수정

### DIFF
--- a/src/documentation/swagger/order.swagger.yaml
+++ b/src/documentation/swagger/order.swagger.yaml
@@ -45,12 +45,6 @@ paths:
         응답 구조:
         `data`: 주문 목록 배열
         `meta`: 페이지네이션 정보 (total, page, limit, totalPages)
-
-        인증 필요:
-        `Bearer 토큰 필수`
-
-        권한:
-        `BUYER` 전용
       security:
         - bearerAuth: []
       parameters:
@@ -320,12 +314,6 @@ paths:
         최소 `1개` 이상의 상품 필요
         포인트는 보유 포인트 범위 내에서만 사용 가능
         재고 부족 시 주문 실패
-
-        인증 필요:
-        `Bearer 토큰 필수`
-
-        권한:
-        `BUYER` 전용
       security:
         - bearerAuth: []
       requestBody:
@@ -755,12 +743,6 @@ paths:
         주의사항:
         본인의 주문만 수정 가능
         결제 완료 전 또는 배송 전에만 수정 권장
-
-        인증 필요:
-        `Bearer 토큰 필수`
-
-        권한:
-        `BUYER` 전용
       security:
         - bearerAuth: []
       parameters:


### PR DESCRIPTION
## 📝 변경 사항
1. 중복 작성된 부분 제거

## 💬 참고사항
저희 swagger config가 아래와 같은 형태로 조합되어 있어서 수정 사항이 안보이던 이슈가 있었습니다.
``` js
apis: [
    './src/documentation/swagger/**/*.yaml', // 개발: tsx watch Hot-reload
    './dist/documentation/swagger/**/*.yaml', // 프로덕션: Docker build
  ],
```
이 옵션은 기본적으로 리스트 내부의 파일들을 다 합친 내용을 보여준다고 해요.

그래서 dist에는 중복된 내용이 있고 src에는 중복을 제거한 내용이었는데 이걸 npm run dev로 실행해서 swagger를 확인하니까 dist 내부의 중복된 부분이 그대로 남아있는게 합쳐져서 수정 사항이 안보이던 상황이 있었습니다.

npm run build로 dist 내부에도 중복된 부분을 제거하니까 그때 제대로 보였습니다.
예상치 못한 상황인데 원인을 찾아서 공유합니다
