### PR TITLE
마이그레이션 충돌 해결 PR

### DIFF
--- a/prisma/migrations/20260108141802_update_payment_schema/migration.sql
+++ b/prisma/migrations/20260108141802_update_payment_schema/migration.sql
@@ -16,7 +16,14 @@ CREATE TYPE "PaymentMethod" AS ENUM ('card', 'point', 'kakaopay', 'naverpay', 't
 -- AlterEnum
 BEGIN;
 CREATE TYPE "PaymentStatus_new" AS ENUM ('processing', 'pending', 'paid', 'failed', 'cancelled', 'completed');
-ALTER TABLE "payments" ALTER COLUMN "status" TYPE "PaymentStatus_new" USING ("status"::text::"PaymentStatus_new");
+
+ALTER TABLE "payments" ALTER COLUMN "status" TYPE "PaymentStatus_new" USING (
+  CASE 
+    WHEN "status"::text = 'CompletedPayment' THEN 'completed'::"PaymentStatus_new"
+    ELSE "status"::text::"PaymentStatus_new"
+  END
+);
+
 ALTER TYPE "PaymentStatus" RENAME TO "PaymentStatus_old";
 ALTER TYPE "PaymentStatus_new" RENAME TO "PaymentStatus";
 DROP TYPE "public"."PaymentStatus_old";

--- a/prisma/migrations/20260109131257_update_stock_schema/migration.sql
+++ b/prisma/migrations/20260109131257_update_stock_schema/migration.sql
@@ -8,27 +8,19 @@
   - Added the required column `size_id` to the `stocks` table without a default value. This is not possible if the table is not empty.
 
 */
--- DropForeignKey
 ALTER TABLE "stocks" DROP CONSTRAINT "stocks_productId_fkey";
-
--- DropForeignKey
 ALTER TABLE "stocks" DROP CONSTRAINT "stocks_sizeId_fkey";
-
--- DropIndex
 DROP INDEX "stocks_productId_sizeId_key";
 
--- AlterTable
-ALTER TABLE "stocks" DROP COLUMN "productId",
-DROP COLUMN "sizeId",
-ADD COLUMN     "product_id" TEXT NOT NULL,
-ADD COLUMN     "reserved_quantity" INTEGER NOT NULL DEFAULT 0,
-ADD COLUMN     "size_id" INTEGER NOT NULL;
+-- 
+ALTER TABLE "stocks" RENAME COLUMN "productId" TO "product_id";
+ALTER TABLE "stocks" RENAME COLUMN "sizeId" TO "size_id";
 
--- CreateIndex
+ALTER TABLE "stocks" ADD COLUMN "reserved_quantity" INTEGER NOT NULL DEFAULT 0;
+
+-- 
 CREATE UNIQUE INDEX "stocks_product_id_size_id_key" ON "stocks"("product_id", "size_id");
 
--- AddForeignKey
 ALTER TABLE "stocks" ADD CONSTRAINT "stocks_product_id_fkey" FOREIGN KEY ("product_id") REFERENCES "products"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
--- AddForeignKey
 ALTER TABLE "stocks" ADD CONSTRAINT "stocks_size_id_fkey" FOREIGN KEY ("size_id") REFERENCES "size"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
## 📝 변경 사항
기존에 prisma에서 자동생성해주는 sql대신
기존 데이터와 충돌나지 않는 sql문으로 수정한 코드입니다.
로컬 테스트 결과 마이그레이션 통과했습니다.

## 🔗 관련 이슈


## ✅ 체크리스트

- [x] 코드 작성 완료
- [x] 로컬에서 테스트 완료
- [x] Lint/Format 검사 통과
- [x] 타입 체크 통과
- [ ] 문서 업데이트 (필요시)

## 💬 참고사항

<!-- 리뷰어에게 알려주고 싶은 내용이나 특별히 확인해야 할 부분 -->
<!-- db 스키마 변동, 패키지 변동 사항 꼭 남겨주세요 -->
